### PR TITLE
Update select_vxls.R

### DIFF
--- a/R/select_vxls.R
+++ b/R/select_vxls.R
@@ -51,7 +51,7 @@ pixelize <- function(D,reduce.by=2){
     seq(1,dim(D)[2]-reduce.by[2]+1,by=reduce.by[2]),
     seq(1,dim(D)[3]-reduce.by[3]+1,by=reduce.by[3]))
   
-#   tcs=D@data$tcs
+    tcs=D@data$tcs
 #   i2=10
 #   i3=10
 #   i1=10
@@ -69,7 +69,7 @@ pixelize <- function(D,reduce.by=2){
     #extract
     tcs=extract_tc(xyz,tcs=tcs,mask=D@mask)
     out=mclapply(1:dim(tcs)[3],function(i)
-                 rowMeans(tcs[,,i],na.rm = na.rm))
+                 na.omit(rowMeans(tcs[,,i],na.rm = na.rm)))
     out=unlist(out)
   }
 


### PR DESCRIPTION
In line 72: rowMeans(tcs[,,i],na.rm = na.rm)
using "na.rm" depends on your system platform. sometimes if sum of the row is NaN or NA, it returns NaN or NA even if you put "na.rm=TRUE". So, it seems that it is better we use "na.omit()" function to avoid this problem i.e. na.omit(rowMeans(tcs[,,i],na.rm = na.rm))).
